### PR TITLE
Fix collections.abc import and deprecation warning regarding invalid escape sequences

### DIFF
--- a/tests/test_classic_connection.py
+++ b/tests/test_classic_connection.py
@@ -18,7 +18,12 @@ import threading
 import time
 import os
 
-from collections import namedtuple, Iterable
+from collections import namedtuple
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 from decimal import Decimal
 
 import pg  # the module under test

--- a/tests/test_classic_functions.py
+++ b/tests/test_classic_functions.py
@@ -180,8 +180,8 @@ class TestParseArray(unittest.TestCase):
         (r"{abc,d,efg}", str, ['abc', 'd', 'efg']),
         ('{Hello World!}', str, ['Hello World!']),
         ('{Hello, World!}', str, ['Hello', 'World!']),
-        ('{Hello,\ World!}', str, ['Hello', ' World!']),
-        ('{Hello\, World!}', str, ['Hello, World!']),
+        (r'{Hello,\ World!}', str, ['Hello', ' World!']),
+        (r'{Hello\, World!}', str, ['Hello, World!']),
         ('{"Hello World!"}', str, ['Hello World!']),
         ('{this, should, be, null}', str, ['this', 'should', 'be', None]),
         ('{This, should, be, NULL}', str, ['This', 'should', 'be', None]),
@@ -449,8 +449,8 @@ class TestParseRecord(unittest.TestCase):
         (r"(\'abc\')", str, ("'abc'",)),
         ('(Hello World!)', str, ('Hello World!',)),
         ('(Hello, World!)', str, ('Hello', ' World!',)),
-        ('(Hello,\ World!)', str, ('Hello', ' World!',)),
-        ('(Hello\, World!)', str, ('Hello, World!',)),
+        (r'(Hello,\ World!)', str, ('Hello', ' World!',)),
+        (r'(Hello\, World!)', str, ('Hello, World!',)),
         ('("Hello World!")', str, ('Hello World!',)),
         ("(this,shouldn't,be,null)", str, ('this', "shouldn't", 'be', 'null')),
         ('(null,should,be,)', str, ('null', 'should', 'be', None)),
@@ -659,8 +659,8 @@ class TestParseHStore(unittest.TestCase):
             '1-a': 'anything at all'}),
         ('"Hello, World!"=>"Hi!"', {'Hello, World!': 'Hi!'}),
         ('"Hi!"=>"Hello, World!"', {'Hi!': 'Hello, World!'}),
-        ('"k=>v"=>k\=\>v', {'k=>v': 'k=>v'}),
-        ('k\=\>v=>"k=>v"', {'k=>v': 'k=>v'}),
+        (r'"k=>v"=>k\=\>v', {'k=>v': 'k=>v'}),
+        (r'k\=\>v=>"k=>v"', {'k=>v': 'k=>v'}),
         ('a\\,b=>a,b=>a', {'a,b': 'a', 'b': 'a'})]
 
     def testParser(self):


### PR DESCRIPTION
Fixes #13 . In addition also fixes deprecation warning regarding invalid escape sequences using raw strings,

```
$ find . -iname '*.py'  | xargs -P 4 -I{} python -Wall -m py_compile {}
       
./tests/test_classic_functions.py:183: DeprecationWarning: invalid escape sequence \ 
  ('{Hello,\ World!}', str, ['Hello', ' World!']),
./tests/test_classic_functions.py:184: DeprecationWarning: invalid escape sequence \,
  ('{Hello\, World!}', str, ['Hello, World!']),
./tests/test_classic_functions.py:452: DeprecationWarning: invalid escape sequence \ 
  ('(Hello,\ World!)', str, ('Hello', ' World!',)),
./tests/test_classic_functions.py:453: DeprecationWarning: invalid escape sequence \,
  ('(Hello\, World!)', str, ('Hello, World!',)),
./tests/test_classic_functions.py:662: DeprecationWarning: invalid escape sequence \=
  ('"k=>v"=>k\=\>v', {'k=>v': 'k=>v'}),
./tests/test_classic_functions.py:663: DeprecationWarning: invalid escape sequence \=
  ('k\=\>v=>"k=>v"', {'k=>v': 'k=>v'}),
```